### PR TITLE
Track recovery source for recovered sales

### DIFF
--- a/client/src/components/dashboard/KPICards.tsx
+++ b/client/src/components/dashboard/KPICards.tsx
@@ -5,6 +5,8 @@ interface KPICardsProps {
   metrics: {
     totalSales: number;
     recoveredSales: number;
+    recoveredPix: number;
+    recoveredCart: number;
     lostSales: number;
     totalClients: number;
     salesGrowth: number;
@@ -44,6 +46,7 @@ export default function KPICards({ metrics }: KPICardsProps) {
     {
       title: "Vendas Recuperadas",
       value: formatCurrency(metrics.recoveredSales),
+      subValue: `PIX: ${formatCurrency(metrics.recoveredPix)} | Carrinho: ${formatCurrency(metrics.recoveredCart)}`,
       growth: formatPercent(metrics.recoveryGrowth),
       growthText: "vs mês anterior",
       icon: RotateCcw,
@@ -82,6 +85,9 @@ export default function KPICards({ metrics }: KPICardsProps) {
               <div>
                 <p className="text-sm text-gray-600 mb-1">{card.title}</p>
                 <p className="text-2xl font-semibold text-gray-800">{card.value}</p>
+                {card.subValue && (
+                  <p className="text-xs text-gray-500">{card.subValue}</p>
+                )}
                 <div className="flex items-center mt-2">
                   <span className={`text-xs font-medium ${card.growthColor}`}>
                     {card.growth}

--- a/client/src/components/kpi-cards.tsx
+++ b/client/src/components/kpi-cards.tsx
@@ -5,6 +5,8 @@ interface KPICardsProps {
   metrics: {
     totalSales: number;
     recoveredSales: number;
+    recoveredPix: number;
+    recoveredCart: number;
     lostSales: number;
     totalClients: number;
     salesGrowth: number;
@@ -40,8 +42,9 @@ export default function KPICards({ metrics }: KPICardsProps) {
       iconColor: "text-green-600",
     },
     {
-      title: "Vendas Recuperadas", 
+      title: "Vendas Recuperadas",
       value: formatCurrency(metrics.recoveredSales),
+      subValue: `PIX: ${formatCurrency(metrics.recoveredPix)} | Carrinho: ${formatCurrency(metrics.recoveredCart)}`,
       growth: metrics.recoveryGrowth,
       icon: Undo2,
       bgColor: "bg-blue-100",
@@ -80,6 +83,9 @@ export default function KPICards({ metrics }: KPICardsProps) {
                 <div>
                   <p className="text-sm text-gray-600 mb-1">{card.title}</p>
                   <p className="text-2xl font-semibold text-gray-800">{card.value}</p>
+                  {card.subValue && (
+                    <p className="text-xs text-gray-500">{card.subValue}</p>
+                  )}
                   <div className="flex items-center mt-2">
                     <TrendIcon className={`${trendColor} text-xs mr-1`} size={12} />
                     <span className={`${trendColor} text-xs font-medium`}>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -82,6 +82,8 @@ export default function Dashboard() {
           <KPICards metrics={{
             totalSales: metrics.totalSales || 0,
             recoveredSales: metrics.recoveredSales || 0,
+            recoveredPix: metrics.recoveredPix || 0,
+            recoveredCart: metrics.recoveredCart || 0,
             lostSales: metrics.lostSales || 0,
             totalClients: metrics.totalClients || 0,
             salesGrowth: metrics.salesGrowth || 0,

--- a/client/src/pages/Reports.tsx
+++ b/client/src/pages/Reports.tsx
@@ -59,6 +59,7 @@ export default function Reports() {
             <div class="kpi-item">
               <h3>Vendas Recuperadas</h3>
               <p>R$ ${metrics?.recoveredSales?.toLocaleString('pt-BR') || '0,00'}</p>
+              <p style="font-size:12px">PIX: R$ ${metrics?.recoveredPix?.toLocaleString('pt-BR') || '0,00'} | Carrinho: R$ ${metrics?.recoveredCart?.toLocaleString('pt-BR') || '0,00'}</p>
             </div>
             <div class="kpi-item">
               <h3>Vendas Perdidas</h3>
@@ -167,6 +168,8 @@ export default function Reports() {
         <KPICards metrics={{
           totalSales: metrics.totalSales,
           recoveredSales: metrics.recoveredSales,
+          recoveredPix: metrics.recoveredPix,
+          recoveredCart: metrics.recoveredCart,
           lostSales: metrics.lostSales,
           totalClients: metrics.totalClients,
           salesGrowth: 15.2,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -33,6 +33,7 @@ export const sales = pgTable("sales", {
   status: varchar("status", { length: 50 }).notNull(), // pending, realized, recovered, lost
   paymentMethod: varchar("payment_method", { length: 100 }),
   eventType: varchar("event_type", { length: 50 }), // PIX_GENERATED, SALE_APPROVED, ABANDONED_CART
+  recoverySource: varchar("recovery_source", { length: 20 }), // 'pix' | 'cart'
   utmCampaign: text("utm_campaign"),
   utmMedium: text("utm_medium"),
   utmContent: text("utm_content"),
@@ -90,6 +91,8 @@ export const insertClientSchema = createInsertSchema(clients).omit({
 export const insertSaleSchema = createInsertSchema(sales).omit({
   id: true,
   date: true,
+}).extend({
+  recoverySource: z.string().optional(),
 });
 
 export const insertSupportTicketSchema = createInsertSchema(supportTickets).omit({
@@ -109,6 +112,7 @@ export type InsertSale = z.infer<typeof insertSaleSchema>;
 export type Sale = typeof sales.$inferSelect & {
   saleId?: string | null;
   eventType?: string | null;
+  recoverySource?: string | null;
   utmCampaign?: string | null;
   utmMedium?: string | null;
   utmContent?: string | null;


### PR DESCRIPTION
## Summary
- add `recoverySource` column to sales schema
- compute recovered sales by PIX and by cart in storage metrics
- mark recovery source when updating sales via webhooks and when fixing existing recoveries
- expose recovery source totals on dashboard/report KPIs
- show PIX and cart breakdown in exported reports

## Testing
- `npm run check` *(fails: cannot find type definitions and many TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a0e05c91c8324914277fd5ae0f7bd